### PR TITLE
fixed malformed copy file

### DIFF
--- a/j1minilte-vendor.mk
+++ b/j1minilte-vendor.mk
@@ -99,4 +99,4 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/j1minilte/proprietary/lib/libvtstack.so:system/lib/libvtstack.so \
     vendor/samsung/j1minilte/proprietary/lib/libwrappergps.so:system/lib/libwrappergps.so \
     vendor/samsung/j1minilte/proprietary/vendor/media/LMspeed_508.emd:system/vendor/media/LMspeed_508.emd \
-    vendor/samsung/j1minilte/proprietary/vendor/media/PFFprec_600.emd:system/vendor/media/PFFprec_600.emd \
+    vendor/samsung/j1minilte/proprietary/vendor/media/PFFprec_600.emd:system/vendor/media/PFFprec_600.emd


### PR DESCRIPTION
build/core/product_config.mk:247: *** device/samsung/j1minilte/lineage.mk: malformed COPY_FILE "\".  Stop.